### PR TITLE
Added Daily Confirmed Cases Card and Covid Chart

### DIFF
--- a/src/PortfolioContainer/Corona/Cards.jsx
+++ b/src/PortfolioContainer/Corona/Cards.jsx
@@ -7,6 +7,7 @@ import cx from "classnames";
 const Cards = ({
   data: { confirmed, recovered, deaths, lastUpdate },
   country,
+  daily,
   }) => {
 
   if (!confirmed) {
@@ -30,6 +31,12 @@ const Cards = ({
     //   value: recovered.value,
     //   bottomText: "Number of recoveries from COVID-19",
     // },
+    {
+      style: styles.daily,
+      text: "New Confirmed",
+      value: daily,
+      bottomText: "New confirmed cases of COVID-19",
+    },
     {
       style: styles.deaths,
       text: "Deaths",
@@ -55,7 +62,7 @@ const Cards = ({
             md={2}
             className={cx(styles.Card, detail.style)}
             key={index}
-            style={{ margin: "0px 75px", padding: "12px" }}
+            style={{ margin: "0px 35px", padding: "12px" }}
           >
             <CardContent>
               <Typography color="textPrimary" gutterBottom>

--- a/src/PortfolioContainer/Corona/Cards.module.css
+++ b/src/PortfolioContainer/Corona/Cards.module.css
@@ -10,6 +10,11 @@
     background-color: rgba(102, 179, 255, 0.5) !important;
     border-bottom: 10px solid rgba(0, 0, 255, 0.5);
   }
+
+  .daily {
+    background-color: rgba(208, 104, 78, 0.5) !important;
+    border-bottom: 10px solid rgba(0, 0, 255, 0.5);
+  }
   
   .recovered {
     background-color: rgba(191, 242, 202, 0.5) !important;

--- a/src/PortfolioContainer/Corona/Chart.jsx
+++ b/src/PortfolioContainer/Corona/Chart.jsx
@@ -4,35 +4,37 @@ import { Line, Bar } from "react-chartjs-2";
 import 'chart.js/auto';
 import styles from "./Chart.module.css";
 
-const Chart = (
-  { data: { confirmed, recovered, deaths }, country }) => {
+const Chart = (props) => {
 
   let lineChart;
 
-  const [dailyData, setDailyData] = useState([]);
+  // const [dailyData, setDailyData] = useState([]);
+  // const [data, setData] = useState(props.data);
 
-  useEffect(() => {
-    const fetchAPI = async () => {
-      setDailyData(await fetchDailyData());
-    };
-    fetchAPI();
-  }, []);
+  const data = props.data
 
-  if(dailyData) {
-  lineChart = dailyData.length ? (
+  // useEffect(() => {
+  //   const fetchAPI = async () => {
+  //     setDailyData(await fetchDailyData());
+  //   };
+  //   fetchAPI();
+  // }, []);
+
+  if(data) {
+  lineChart = data.length ? (
     <Line
       data={{
-        labels: dailyData.map(({ date }) => date),
+        labels: data.map(({ date }) => date),
         datasets: [
           {
-            data: dailyData.map(({ confirmed }) => confirmed),
-            label: "Infected",
+            data: data.map(({ confirmed }) => confirmed),
+            label: "Daily Confirmed Cases",
             borderColor: "#3333ff",
             fill: true,
           },
           {
-            data: dailyData.map(({ deaths }) => deaths),
-            label: "Deaths",
+            data: data.map(({ deaths }) => deaths),
+            label: "Daily Deaths",
             borderColor: "red",
             backgroundColor: "rgba(255,0,0,0.5)",
             fill: true,
@@ -43,43 +45,43 @@ const Chart = (
   ) : null;
     }
 
-  const barChart = confirmed ? (
-    <Bar
-      data={{
-        labels: ["Infected", "Recovered", "Deaths", "Active"],
-        datasets: [
-          {
-            label: "People",
-            backgroundColor: [
-              "rgba(0, 0, 255, 0.5)",
-              "rgba(0, 255, 0, 0.5)",
-              "rgba(255, 0, 0, 0.5)",
-              "rgba(242, 234, 0, 0.5)",
-            ],
-            hoverBackgroundColor: [
-              "rgba(0, 77, 153)",
-              "rgba(30, 102, 49)",
-              "rgba(255, 51, 51)",
-              "rgba(204, 153, 0)",
-            ],
-            data: [
-              confirmed.value,
-              recovered.value,
-              deaths.value,
-              confirmed.value - (recovered.value + deaths.value),
-            ],
-          },
-        ],
-      }}
-      options={{
-        legend: { display: false },
-        title: { display: true, text: `Current state in ${country}` },
-      }}
-    />
-  ) : null;
+  // const barChart = confirmed ? (
+  //   <Bar
+  //     data={{
+  //       labels: ["Infected", "Recovered", "Deaths", "Active"],
+  //       datasets: [
+  //         {
+  //           label: "People",
+  //           backgroundColor: [
+  //             "rgba(0, 0, 255, 0.5)",
+  //             "rgba(0, 255, 0, 0.5)",
+  //             "rgba(255, 0, 0, 0.5)",
+  //             "rgba(242, 234, 0, 0.5)",
+  //           ],
+  //           hoverBackgroundColor: [
+  //             "rgba(0, 77, 153)",
+  //             "rgba(30, 102, 49)",
+  //             "rgba(255, 51, 51)",
+  //             "rgba(204, 153, 0)",
+  //           ],
+  //           data: [
+  //             confirmed.value,
+  //             recovered.value,
+  //             deaths.value,
+  //             confirmed.value - (recovered.value + deaths.value),
+  //           ],
+  //         },
+  //       ],
+  //     }}
+  //     options={{
+  //       legend: { display: false },
+  //       title: { display: true, text: `Current state in ${country}` },
+  //     }}
+  //   />
+  // ) : null;
 
   return (
-    <div className={styles.container}>{country ? barChart : lineChart}</div>
+    <div className={styles.container}>{lineChart}</div>
   );
 };
 

--- a/src/PortfolioContainer/PortfolioContainer.js
+++ b/src/PortfolioContainer/PortfolioContainer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { TOTAL_SCREENS } from '../utilities/commonUtils';
 import axios from 'axios';
 
-import { fetchData } from '../api';
+import { fetchData, fetchNewConfirmed, fetchGlobalData  } from '../api';
 
 import Cards from './Corona/Cards.jsx';
 import Chart from './Corona/Chart.jsx';
@@ -29,6 +29,13 @@ export default function PortfolioContainer() {
    const [country, setCountry] = useState(' ');
    const [covidData, setCovidData] = useState({});
 
+
+   // Daily New Covid Data 
+   // dailyCovidDataList is an array containing like over 700 days of data
+   // dailyCovidData is a day of covid data
+   const [dailyCovidDataList, setDailyCovidDataList] = useState([]);
+   const [dailyCovidData, setDailyCovidData] = useState();
+
    // This function loads the first thing the page loads
    // creates a asynchornous function which
    // calls the fetchData() function from index.js
@@ -38,19 +45,25 @@ export default function PortfolioContainer() {
          const APIData = await fetchData();
          console.log(APIData);
          setCovidData(APIData);
+
+         const globalDaily = await fetchGlobalData();
+         setDailyCovidData(globalDaily[0].confirmed);
+         setDailyCovidDataList(globalDaily);
+         console.log(globalDaily);
       };
 
       loadAPI();
    }, []);
 
-   // fetches and sets the covid data of a country
+   // Fetches and sets the covid data of a country 
+   // using mathdroid's covid api
    const getAndSetCountryData = async (country) => {
       const gd = await fetchData(country);
       console.log(gd);
       setCovidData(gd);
    };
 
-   // sets variables and the update functions
+   // Sets variables and the update functions
    // for longitude and latitude
    // default variables are within useState parentheses
    const [lat, setLat] = useState(37.3382);
@@ -76,11 +89,26 @@ export default function PortfolioContainer() {
             // covid cards and chart
             setCountry(response.data.sys.country);
             getAndSetCountryData(response.data.sys.country);
+
+            getCountryDailyCovidData(response.data.sys.country)
          });
          // Resets the search text to ''
          setLocation('');
       }
    };
+
+   // Gets a country's daily covid data array 
+   // and the current daily covid cases.
+   // It sets the const DailyCovidDataList to the array.
+   // Also sets the daily covid cases which is 
+   // the first element of that array.
+   const getCountryDailyCovidData = async (country) => {
+      const daily_data = await fetchNewConfirmed(country)
+      // console.log(daily_data)
+      setDailyCovidDataList(daily_data)
+      setDailyCovidData(daily_data[0].confirmed)
+      console.log(daily_data[0].confirmed)
+    }
 
    return (
       <div>
@@ -118,8 +146,8 @@ export default function PortfolioContainer() {
             key={Corona.screen_name}
             id={Corona.screen_name}
          />
-         <Cards data={covidData} country={country}></Cards>
-         <Chart data={covidData} country={country}></Chart>
+         <Cards data={covidData} country={country} daily={dailyCovidData}></Cards>
+         <Chart data={dailyCovidDataList} country={country}></Chart>
       </div>
    );
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 
 const url = "https://covid19.mathdro.id/api";
+const about_corona_url = "https://corona-api.com"
+
 
 export const fetchData = async (country) => {
   let changeableUrl = url;
@@ -44,5 +46,50 @@ export const fetchCountries = async () => {
     return countries.map((country) => country.name);
   } catch (error) {
     console.log(error);
+  }
+};
+
+export const fetchNewConfirmed = async (country) => {
+  try {
+    const { data } = await axios.get(`${about_corona_url}/countries/${country}`);
+    // console.log(data)
+
+    // gets the current day covid data
+    // console.log(data.data.timeline[0])
+    // console.log(data.data.timeline)
+
+    // data.data.timeline is an array of days and their respective data attributes
+
+    // maps the json timeline data into a const 
+    // slice(0,30) gets the last 31 days 
+    const modifiedData = data.data.timeline.slice(0,30).map((dailyConfirmed) => ({
+      confirmed: dailyConfirmed.new_confirmed,
+      deaths: dailyConfirmed.new_deaths,
+      date: dailyConfirmed.date,
+    }));
+
+    console.log(modifiedData)
+    return modifiedData;
+
+  } catch (error) {
+    console.log(error)
+  }
+};
+
+export const fetchGlobalData = async () => {
+  try {
+    const { data } = await axios.get(`${about_corona_url}/timeline`);
+    // const modifiedData = data.data[1].new_confirmed;
+    const modifiedData = data.data.slice(0,30).map((dailyConfirmed) => ({
+      confirmed: dailyConfirmed.new_confirmed,
+      deaths: dailyConfirmed.new_deaths,
+      date: dailyConfirmed.date,
+    }));
+
+    console.log(modifiedData)
+    return modifiedData;
+
+  } catch (error) {
+    console.log(error)
   }
 };


### PR DESCRIPTION
Added daily new confirmed COVID cases card and chart of past 30 day new confirmed cases and chart. 
The chart starts from latest day to 30 days in the past and I was unable to reverse the data without things breaking
Chart also has some errors of a day having two days worth of data but that's on about-corona's api.