### PR TITLE
Split charts to two and updated css

### DIFF
--- a/src/PortfolioContainer/Corona/Chart.jsx
+++ b/src/PortfolioContainer/Corona/Chart.jsx
@@ -22,26 +22,35 @@ const Chart = (props) => {
 
   if(data) {
   lineChart = data.length ? (
-    <Line
+    <div>
+      <Line
+        data={{
+          labels: data.map(({ date }) => date),
+          datasets: [
+            {
+              data: data.map(({ confirmed }) => confirmed),
+              label: "Daily Confirmed Cases",
+              borderColor: "#3333ff",
+              fill: true,
+            },
+          ],
+        }}
+      />
+      <Line
       data={{
-        labels: data.map(({ date }) => date),
-        datasets: [
-          {
-            data: data.map(({ confirmed }) => confirmed),
-            label: "Daily Confirmed Cases",
-            borderColor: "#3333ff",
-            fill: true,
-          },
-          {
-            data: data.map(({ deaths }) => deaths),
-            label: "Daily Deaths",
-            borderColor: "red",
-            backgroundColor: "rgba(255,0,0,0.5)",
-            fill: true,
-          },
-        ],
-      }}
-    />
+          labels: data.map(({ date }) => date),
+          datasets: [
+            {
+              data: data.map(({ deaths }) => deaths),
+              label: "Daily Deaths",
+              borderColor: "red",
+              backgroundColor: "rgba(255,0,0,0.5)",
+              fill: true,
+            },
+          ],
+        }}
+      />
+    </div>
   ) : null;
     }
 

--- a/src/PortfolioContainer/Corona/Chart.module.css
+++ b/src/PortfolioContainer/Corona/Chart.module.css
@@ -1,15 +1,22 @@
 .container {
-   display: flex;
+   /* display: flex; */
    justify-content: center;
-   width: 85%;
+   width: 70%;
    margin-left: auto;
    margin-right: auto;
 }
+
+/* .charts {
+   max-width: 700px;
+   max-height: 500px;
+} */
+
 @media (max-width: 770px) {
    .container {
       width: 100%;
    }
    .image {
       width: 100%;
+      height: max-content;
    }
 }

--- a/src/PortfolioContainer/PortfolioContainer.css
+++ b/src/PortfolioContainer/PortfolioContainer.css
@@ -1,3 +1,9 @@
+.search {
+   width: 50%;
+   margin: 0 auto;
+   text-align: center;
+}
+
 .search input {
    margin: 0 auto;
 }

--- a/src/PortfolioContainer/PortfolioContainer.js
+++ b/src/PortfolioContainer/PortfolioContainer.js
@@ -11,7 +11,7 @@ import './PortfolioContainer.css';
 
 export default function PortfolioContainer() {
    // Sets a const for every component from
-   // component array in commonUtils.js
+   // the component array in commonUtils.js
    const Home = TOTAL_SCREENS[0];
    const Map = TOTAL_SCREENS[1];
    const Weather = TOTAL_SCREENS[2];
@@ -31,8 +31,9 @@ export default function PortfolioContainer() {
 
 
    // Daily New Covid Data 
-   // dailyCovidDataList is an array containing like over 700 days of data
-   // dailyCovidData is a day of covid data
+   // dailyCovidDataList is an array containing days of Covid data
+   // dailyCovidData is the covid data of most recent day
+   // Uses the about-corona api
    const [dailyCovidDataList, setDailyCovidDataList] = useState([]);
    const [dailyCovidData, setDailyCovidData] = useState();
 
@@ -42,14 +43,24 @@ export default function PortfolioContainer() {
    // and sets the intial Covid data for the cards and chart
    useEffect(() => {
       const loadAPI = async () => {
+         // mathdroid's Corona api
          const APIData = await fetchData();
          console.log(APIData);
          setCovidData(APIData);
 
+         // array of about-corona's api 
          const globalDaily = await fetchGlobalData();
+
+         // Sets today's recent Covid Data which is the 
+         // first element in the array  
          setDailyCovidData(globalDaily[0].confirmed);
-         setDailyCovidDataList(globalDaily);
-         console.log(globalDaily);
+
+         // Reverses the array so the last element 
+         // is the most recent day
+         // setDailyCovidDataList(globalDaily);
+         const reverse_globalDaily = globalDaily.reverse();
+         setDailyCovidDataList(reverse_globalDaily);
+         console.log(reverse_globalDaily);
       };
 
       loadAPI();
@@ -74,14 +85,16 @@ export default function PortfolioContainer() {
    const key = '7f58ed63d7854545d442c43cba9d26af';
    let url = `https://api.openweathermap.org/data/2.5/weather?q=${location}&units=imperial&appid=${key}`;
 
+   // Searches OpenWeatherMap, calls other functions
+   // which get or set data with the country of inputted city
    const searchLocation = (event) => {
       if (event.key === 'Enter') {
          axios.get(url).then((response) => {
-            // sets OpenWeatherMap data
+            // Sets OpenWeatherMap data
             setData(response.data);
             console.log(response.data);
 
-            // sets Latitude and Longitude for maps
+            // Sets Latitude and Longitude for maps
             setLat(response.data.coord.lat);
             setLon(response.data.coord.lon);
 
@@ -90,6 +103,7 @@ export default function PortfolioContainer() {
             setCountry(response.data.sys.country);
             getAndSetCountryData(response.data.sys.country);
 
+            // Sets the country's daily confirmed covid cases and deaths
             getCountryDailyCovidData(response.data.sys.country)
          });
          // Resets the search text to ''
@@ -105,9 +119,11 @@ export default function PortfolioContainer() {
    const getCountryDailyCovidData = async (country) => {
       const daily_data = await fetchNewConfirmed(country)
       // console.log(daily_data)
-      setDailyCovidDataList(daily_data)
       setDailyCovidData(daily_data[0].confirmed)
-      console.log(daily_data[0].confirmed)
+
+
+      const reverse_globalDaily = daily_data.reverse();
+      setDailyCovidDataList(reverse_globalDaily);
     }
 
    return (

--- a/src/PortfolioContainer/Weather/Weather.css
+++ b/src/PortfolioContainer/Weather/Weather.css
@@ -3,7 +3,7 @@
    flex-direction: column;
    justify-content: center;
    align-items: center;
-   margin: 50px 0 0 0;
+   margin: 50px 75px 0;
 }
 
 .weather-parent {
@@ -41,6 +41,7 @@ h1 {
    position: relative;
    background-color: rgba(0, 0, 0, 0.4);
    color: #fff;
+   border-radius: 25px;
 }
 
 .weather-app:before {
@@ -53,6 +54,7 @@ h1 {
    left: 0;
    right: 0;
    z-index: -1;
+   border-radius: 25px;
 }
 
 .weather-app .weather-search {
@@ -107,7 +109,7 @@ h1 {
    /*border: 1px solid white;*/
 }
 
-.weather-app .weather-bottom {
+.weather-app .weather-bottom{
    display: flex;
    justify-content: space-evenly;
    text-align: center;
@@ -117,7 +119,7 @@ h1 {
    border-radius: 12px;
    background-color: rgba(255, 255, 255, 0.2);
    position: relative;
-   top: -100px;
+   top: -150px;
 }
 
 .bold {


### PR DESCRIPTION
- Split Covid Charts to two, so one with new daily confirmed cases of past 30 days and new deaths of the past 30 days
- Reversed data array so chart has most recent day at the rightmost point instead of leftmost point
- Centered search bars
- Fixed bottom weather from being cut off but check on different resolutions
- Added margins to weather component and rounded corners
- Added new comments explaining functions in main component 
